### PR TITLE
update murshun_cigs_fnc_take_cig_from_pack

### DIFF
--- a/addons/murshun_cigs/functions/fn_preInit.sqf
+++ b/addons/murshun_cigs/functions/fn_preInit.sqf
@@ -295,10 +295,11 @@ murshun_cigs_fnc_take_cig_from_pack = {
     [_player, "murshun_cigs_unwrap"] call murshun_cigs_playSound;
 
     if (goggles _player == "") then {
-        _player addItem "murshun_cigs_cig0";
+        _player addGoggles "murshun_cigs_cig0";
     } else {
         if (hmd _player == "") then {
             _player addItem "murshun_cigs_cig0_nv";
+            _player assignItem "murshun_cigs_cig0_nv";            
         } else {
             _player addItem "murshun_cigs_cig0";
         };


### PR DESCRIPTION
if Face is free, add cigs as goggles, else if NVG is free, add cig and assign to nvg slot, if both are blocked, add normal cig to inventory.